### PR TITLE
Updated to add corresponding host for %h in injections

### DIFF
--- a/resources/injections
+++ b/resources/injections
@@ -14,10 +14,13 @@
 #param,src,http://%s/
 #param,ref,http://%s/
 #param,referrer,http://%s/
+# %h is replaced with corresponding Host header
+# Useful in cases like Host, Origin, etc.
+#header,Host,%s:80@%h
 header,Contact,root@%s
 header,From,root@%s
 header,User-Agent,Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36 root@%s
-header,Referer,http://%s/ref
+#header,Referer,http://%s/ref
 #header,X-Original-URL,http://%s/
 header,X-Wap-Profile,http://%s/wap.xml
 #header,Profile,http://%s/wap.xml

--- a/resources/injections
+++ b/resources/injections
@@ -20,7 +20,7 @@
 header,Contact,root@%s
 header,From,root@%s
 header,User-Agent,Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36 root@%s
-#header,Referer,http://%s/ref
+header,Referer,http://%s/ref
 #header,X-Original-URL,http://%s/
 header,X-Wap-Profile,http://%s/wap.xml
 #header,Profile,http://%s/wap.xml

--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -262,6 +262,8 @@ class Injector implements IProxyListener {
 
         for (String[] injection: injectionPoints) {
             String payload = injection[2].replace("%s", collab.generateCollabId(requestCode, injection[1]));
+	    // replace %h with corresponding Host header (same as with %s for Collaborator)
+	    payload = payload.replace("%h", Utilities.getHeader(request, "Host"));
             switch ( injection[0] ){
                 case "param":
                     IParameter param = Utilities.helpers.buildParameter(injection[1], payload, IParameter.PARAM_URL);


### PR DESCRIPTION
\# %h is replaced with corresponding Host header
\# Useful in cases like Host, Origin, etc.
header,Host,%s:80@%h