### PR TITLE
Tamper only with in-scope requests

### DIFF
--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -296,7 +296,13 @@ class Injector implements IProxyListener {
         }
 
         IHttpRequestResponse messageInfo = proxyMessage.getMessageInfo();
-
+	
+	// only tamper with requests that are in scope
+	IRequestInfo reqinfo = Utilities.helpers.analyzeRequest(messageInfo.getHttpService(), messageInfo.getRequest());
+	
+	if (!Utilities.callbacks.isInScope(reqinfo.getUrl())) {
+		return;
+	}
 
         // don't tamper with requests already heading to the collaborator
         if (messageInfo.getHttpService().getHost().endsWith(collab.getLocation())) {


### PR DESCRIPTION
Version 1.30 of Collaborator Everywhere does not take into account whether the processed request is in scope (see #6 )