### PR TITLE
Fix CloudFlare's CF-Connecting-IP header

### DIFF
--- a/resources/injections
+++ b/resources/injections
@@ -41,5 +41,5 @@ header,Client-IP,spoofed.%s
 header,X-Client-IP,spoofed.%s
 header,X-Real-IP,spoofed.%s
 header,X-Originating-IP,spoofed.%s
-header,CF-Connecting_IP,spoofed.%s
+header,CF-Connecting-IP,spoofed.%s
 header,Forwarded,for=spoofed.%s;by=spoofed.%s;host=spoofed.%s


### PR DESCRIPTION
According to https://support.cloudflare.com/hc/en-us/articles/200170986-How-does-Cloudflare-handle-HTTP-Request-headers- the "Connecting" and "IP" parts are delimited with a dash. I assume the underscore is a typo.